### PR TITLE
Remove ini_set calls

### DIFF
--- a/src/Slim/Middleware/Session.php
+++ b/src/Slim/Middleware/Session.php
@@ -99,7 +99,6 @@ class Session
         }
 
         session_name($name);
-        session_cache_limiter(false);
         session_start();
     }
 }

--- a/src/Slim/Middleware/Session.php
+++ b/src/Slim/Middleware/Session.php
@@ -50,10 +50,6 @@ class Session
             $settings['lifetime'] = strtotime($lifetime) - time();
         }
         $this->settings = $settings;
-
-        ini_set('session.gc_probability', 1);
-        ini_set('session.gc_divisor', 1);
-        ini_set('session.gc_maxlifetime', 30 * 24 * 60 * 60);
     }
 
     /**


### PR DESCRIPTION
Seems like a bad idea in general for a package to do ini_set calls, but I also guess different sites will have different garbage collection needs. See http://somethingemporium.com/2007/06/obscure-error-with-php5-on-debian-ubuntu-session-phpini-garbage for one particular issue I ran into.

If you really recommend using these settings, I suggest adding them to the README instead. 

I also removed `session_cache_limiter(false)`, since it accepts a string, not a boolean.
