### PR TITLE
Check session_status

### DIFF
--- a/src/Slim/Middleware/Session.php
+++ b/src/Slim/Middleware/Session.php
@@ -104,6 +104,8 @@ class Session
 
         session_name($name);
         session_cache_limiter(false);
-        session_start();
+        if ( session_status() == PHP_SESSION_NONE ) {
+            session_start();
+        }
     }
 }


### PR DESCRIPTION
To prevent "a session had already been started - ignoring session_start()" notice
lets first check session_status before attempting to call session_start.