### PR TITLE
Support to slim/csrf plugin

### DIFF
--- a/src/Slim/Middleware/Session.php
+++ b/src/Slim/Middleware/Session.php
@@ -43,6 +43,7 @@ class Session
             'httponly'    => false,
             'name'        => 'slim_session',
             'autorefresh' => false,
+            'csrf'        => false
         ];
         $settings = array_merge($defaults, $settings);
 
@@ -54,6 +55,8 @@ class Session
         ini_set('session.gc_probability', 1);
         ini_set('session.gc_divisor', 1);
         ini_set('session.gc_maxlifetime', 30 * 24 * 60 * 60);
+        
+        if($settings['csrf']) $this->startSession();
     }
 
     /**


### PR DESCRIPTION
Added in the constructor the call to startSession in order to co-exist with slim/csrf plugin