### PR TITLE
Added return $this to Helper Class

### DIFF
--- a/src/SlimSession/Helper.php
+++ b/src/SlimSession/Helper.php
@@ -100,8 +100,6 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
 
     /**
      * Destroy the session.
-     *
-     * @return $this
      */
     public static function destroy()
     {
@@ -123,8 +121,6 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
                 );
             }
         }
-
-        return $this;
     }
 
     /**

--- a/src/SlimSession/Helper.php
+++ b/src/SlimSession/Helper.php
@@ -32,30 +32,42 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @param string $key
      * @param mixed  $value
+     *
+     * @return $this
      */
     public function set($key, $value)
     {
         $_SESSION[$key] = $value;
+
+        return $this;
     }
 
     /**
      * Delete a session variable.
      *
      * @param string $key
+     *
+     * @return $this
      */
     public function delete($key)
     {
         if ($this->exists($key)) {
             unset($_SESSION[$key]);
         }
+
+        return $this;
     }
 
     /**
      * Clear all session variables.
+     *
+     * @return $this
      */
     public function clear()
     {
         $_SESSION = [];
+
+        return $this;
     }
 
     /**
@@ -88,6 +100,8 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
 
     /**
      * Destroy the session.
+     *
+     * @return $this
      */
     public static function destroy()
     {
@@ -109,6 +123,8 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
                 );
             }
         }
+
+        return $this;
     }
 
     /**
@@ -205,19 +221,27 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @param mixed $offset
      * @param mixed $value
+     *
+     * @return $this
      */
     public function offsetSet($offset, $value)
     {
         $this->set($offset, $value);
+
+        return $this;
     }
 
     /**
      * Remove a value by offset.
      *
      * @param mixed $offset
+     *
+     * @return $this
      */
     public function offsetUnset($offset)
     {
         $this->delete($offset);
+
+        return $this;
     }
 }

--- a/src/SlimSession/Helper.php
+++ b/src/SlimSession/Helper.php
@@ -217,27 +217,19 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @param mixed $offset
      * @param mixed $value
-     *
-     * @return $this
      */
     public function offsetSet($offset, $value)
     {
         $this->set($offset, $value);
-
-        return $this;
     }
 
     /**
      * Remove a value by offset.
      *
      * @param mixed $offset
-     *
-     * @return $this
      */
     public function offsetUnset($offset)
     {
         $this->delete($offset);
-
-        return $this;
     }
 }


### PR DESCRIPTION
This pull request adds 'return $this' to some Helper methods so it can be chained jQuery-like.
i.e. `$session->delete('key')->set('key2', 'value')->delete('key3');`