### PR TITLE
$settings['autorefresh'] useless

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ $app->get('/', function () {
   $exists = $session->exists('my_key');
   $exists = isset($session->my_key);
   $exists = isset($session['my_key']);
+
+  // Get All variable
+  $ses =  $session->getIterator();
   
   // Get a variable
   $my_value = $session->get('my_key', 'default');

--- a/src/Slim/Middleware/Session.php
+++ b/src/Slim/Middleware/Session.php
@@ -87,27 +87,22 @@ class Session
             $settings['secure'],
             $settings['httponly']
         );
-
-        $active = session_status() === PHP_SESSION_ACTIVE;
-
-        if ($active) {
-            if ($settings['autorefresh'] && isset($_COOKIE[$name])) {
-                setcookie(
-                    $name,
-                    $_COOKIE[$name],
-                    time() + $settings['lifetime'],
-                    $settings['path'],
-                    $settings['domain'],
-                    $settings['secure'],
-                    $settings['httponly']
-                );
-            }
-        }
-
         session_name($name);
         session_cache_limiter(false);
-        if (!$active) {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
             session_start();
+        }
+
+        if (session_status() === PHP_SESSION_ACTIVE && $settings['autorefresh'] && isset($_COOKIE[$name])) {
+            setcookie(
+                $name,
+                $_COOKIE[$name],
+                time() + $settings['lifetime'],
+                $settings['path'],
+                $settings['domain'],
+                $settings['secure'],
+                $settings['httponly']
+            );
         }
     }
 }

--- a/src/Slim/Middleware/Session.php
+++ b/src/Slim/Middleware/Session.php
@@ -88,26 +88,31 @@ class Session
             $settings['httponly']
         );
 
-        $active = session_status() === PHP_SESSION_ACTIVE;
 
-        if ($active) {
-            if ($settings['autorefresh'] && isset($_COOKIE[$name])) {
-                setcookie(
-                    $name,
-                    $_COOKIE[$name],
-                    time() + $settings['lifetime'],
-                    $settings['path'],
-                    $settings['domain'],
-                    $settings['secure'],
-                    $settings['httponly']
-                );
-            }
-        }
+	$inactive = session_status() === PHP_SESSION_NONE; // ignore PHP_SESSION_DISABLED 
+	if ($inactive) {
+		// when using $active = session_status() === PHP_SESSION_ACTIVE; 
+		// this line never called, so the lifetime never ascending
+    		if ($settings['autorefresh'] && isset($_COOKIE[$name])) {
+	        	setcookie(
+            			$name,
+            			$_COOKIE[$name],
+        	    		time() + $settings['lifetime'],
+        	    		$settings['path'],
+				$settings['domain'],
+        	    		$settings['secure'],
+		            	$settings['httponly']
+        		);
+    		}
+	}
+	session_name($name);
+	session_cache_limiter(false);
+	if ($inactive) {
+	    session_start();
+	}
 
-        session_name($name);
-        session_cache_limiter(false);
-        if (!$active) {
-            session_start();
-        }
+
+
+
     }
 }


### PR DESCRIPTION
when enabled, session_status() always return PHP_SESSION_NONE before session_start(); 
therefore `$settings['autorefresh']=true` become useless, setcookie never callled