### PR TITLE
Renamed Helper class to SessionHelper

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $container = $app->getContainer();
 
 // Register globally to app
 $container['session'] = function ($c) {
-  return new \SlimSession\Helper;
+  return new \SlimSession\SessionHelper;
 };
 ```
 
@@ -64,7 +64,7 @@ That will provide `$app->session`, so you can do:
 ```php
 $app->get('/', function ($req, $res) {
   // or $this->session if registered
-  $session = new \SlimSession\Helper;
+  $session = new \SlimSession\SessionHelper;
 
   // Check if variable exists
   $exists = $session->exists('my_key');

--- a/src/SlimSession/SessionHelper.php
+++ b/src/SlimSession/SessionHelper.php
@@ -10,7 +10,7 @@ namespace SlimSession;
  *
  * @package SlimSession
  */
-class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
+class SessionHelper implements \ArrayAccess, \Countable, \IteratorAggregate
 {
     /**
      * Get a session variable.


### PR DESCRIPTION
The name Helper is very ambigous. It could be an App Helper, a Middleware Helper or something else. The name SessionHelper defines correctly, what the helper does. It is more readable, if your read the code like this:
```php
use SlimSession\SessionHelper;

$session = new SessionHelper();
```
instead of this:
```php
use SlimSession\Helper;

$session = new Helper();
```