### PR TITLE
Iniset remove hardcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $app->add(new \Slim\Middleware\Session([
   is made (interaction with server).
 * `handler`: Custom session handler class or object. Must implement
   `SessionHandlerInterface` as required by PHP.
-* `ini_settings`: array of php.ini directives [related to the sessions](http://php.net/manual/en/session.configuration.php) (as keys) with overriding values (for ex: `['session.gc_maxlifetime' => 86400]`)
+* `ini_settings`: array of php.ini directives [related to the sessions](http://php.net/manual/en/session.configuration.php) (as keys) with overriding values (for ex: `['session.gc_maxlifetime' => 86400]`). _Note: previous versions of the package has set some hardcoded values of INI-settings which could lead performance leaks: `['session.gc_probability' => 1, 'session.gc_divisor' => 1, 'session.gc_maxlifetime' => 30 * 24 * 60 * 60 ]`_
 
 
 ## Session helper

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ $app->add(new \Slim\Middleware\Session([
   is made (interaction with server).
 * `handler`: Custom session handler class or object. Must implement
   `SessionHandlerInterface` as required by PHP.
+* `ini_settings`: array of php.ini directives [related to the sessions](http://php.net/manual/en/session.configuration.php) (as keys) with overriding values (for ex: `['session.gc_maxlifetime' => 86400]`)
 
 
 ## Session helper

--- a/src/Slim/Middleware/Session.php
+++ b/src/Slim/Middleware/Session.php
@@ -53,9 +53,12 @@ class Session
         }
         $this->settings = $settings;
 
-        $ini = $this->settings['ini_settings'];
+        $ini = $settings['ini_settings'];
         if (!empty($ini) && is_array($ini)) {
             $this->iniSet($ini);
+        }
+        if (!isset($ini['session.gc_maxlifetime']) && (ini_get('session.gc_maxlifetime') < $settings['lifetime'])) {
+            $this->iniSet('session.gc_maxlifetime', $settings['lifetime'] * 2);
         }
     }
 

--- a/src/Slim/Middleware/Session.php
+++ b/src/Slim/Middleware/Session.php
@@ -36,14 +36,15 @@ class Session
     public function __construct($settings = [])
     {
         $defaults = [
-            'lifetime'    => '20 minutes',
-            'path'        => '/',
-            'domain'      => null,
-            'secure'      => false,
-            'httponly'    => false,
-            'name'        => 'slim_session',
-            'autorefresh' => false,
-            'handler'     => null,
+            'lifetime'     => '20 minutes',
+            'path'         => '/',
+            'domain'       => null,
+            'secure'       => false,
+            'httponly'     => false,
+            'name'         => 'slim_session',
+            'autorefresh'  => false,
+            'handler'      => null,
+            'ini_settings' => []
         ];
         $settings = array_merge($defaults, $settings);
 
@@ -52,9 +53,10 @@ class Session
         }
         $this->settings = $settings;
 
-        ini_set('session.gc_probability', 1);
-        ini_set('session.gc_divisor', 1);
-        ini_set('session.gc_maxlifetime', 30 * 24 * 60 * 60);
+        $ini = $this->settings['ini_settings'];
+        if (!empty($ini) && is_array($ini)) {
+            $this->iniSet($ini);
+        }
     }
 
     /**
@@ -120,6 +122,14 @@ class Session
         session_cache_limiter(false);
         if ($inactive) {
             session_start();
+        }
+    }
+
+    private function iniSet($settings) {
+        foreach ($settings as $key => $val) {
+            if (strpos($key, 'session.') === 0) {
+                ini_set($key, $val);
+            }
         }
     }
 }

--- a/src/Slim/Middleware/Session.php
+++ b/src/Slim/Middleware/Session.php
@@ -125,7 +125,7 @@ class Session
         }
     }
 
-    private function iniSet($settings) {
+    protected function iniSet($settings) {
         foreach ($settings as $key => $val) {
             if (strpos($key, 'session.') === 0) {
                 ini_set($key, $val);

--- a/src/Slim/Middleware/Session.php
+++ b/src/Slim/Middleware/Session.php
@@ -57,8 +57,8 @@ class Session
         if (!empty($ini) && is_array($ini)) {
             $this->iniSet($ini);
         }
-        if (!isset($ini['session.gc_maxlifetime']) && (ini_get('session.gc_maxlifetime') < $settings['lifetime'])) {
-            $this->iniSet('session.gc_maxlifetime', $settings['lifetime'] * 2);
+        if (!isset($ini['session.gc_maxlifetime']) && (intval(ini_get('session.gc_maxlifetime')) < $settings['lifetime'])) {
+            $this->iniSet(['session.gc_maxlifetime' => $settings['lifetime'] * 2]);
         }
     }
 


### PR DESCRIPTION
There was a problem in constructor of Session class: three calls of `ini_set()` with hardcoded values for `session.gc_probability`, `session.gc_divisor` and `session.gc_maxlifetime`. It caused serious performance leaks (in my case ~500K session files that was checked by GC on each request - as a result each call of `session_start()` takes ~2 seconds).

I think, it would be correct to rely on global values for this directives (that defined in php.ini file), but give a possibility to change it with settings array passed to the class constructor.