### PR TITLE
Fix issue #32

### DIFF
--- a/src/Slim/Middleware/Session.php
+++ b/src/Slim/Middleware/Session.php
@@ -85,6 +85,8 @@ class Session
     {
         $settings = $this->settings;
         $name = $settings['name'];
+        
+        session_write_close();
 
         session_set_cookie_params(
             $settings['lifetime'],


### PR DESCRIPTION
A fix for this warning `session_set_cookie_params(): Cannot change session cookie parameters when session is active`

See issue : https://github.com/bryanjhv/slim-session/issues/32