### PR TITLE
Resolve #32. $inactive now acts at a higher scope. 

### DIFF
--- a/src/Slim/Middleware/Session.php
+++ b/src/Slim/Middleware/Session.php
@@ -56,7 +56,7 @@ class Session
         
         $this->inactive = session_status() === PHP_SESSION_NONE;
         
-        if($this->inactive){
+        if($this->inactive) {
             $this->iniSet($settings['ini_settings']);
             // Just override this, to ensure package is working
             if (ini_get('session.gc_maxlifetime') < $settings['lifetime']) {
@@ -78,7 +78,7 @@ class Session
      */
     public function __invoke(Request $request, Response $response, callable $next)
     {
-        if($this->inactive){
+        if($this->inactive) {
             $this->startSession();
         }
 


### PR DESCRIPTION
Resolving #32. Should resolve warnings about:

`ini_set`
`session_set_cookie_params`
`session_name`
`session_cache_limiter`

Working on seeing whether this breaks anything. I'd be surprised if it did, but I don't know what I don't know about sessions. 