### PR TITLE
Prepare for PHP 8.1+ (avoid deprecation warnings but drop PHP 7 support)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,10 +22,11 @@
     "source": "https://github.com/bryanjhv/slim-session.git"
   },
   "require": {
+    "php": ">=8",
     "slim/slim": "^4.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.0"
+    "phpunit/phpunit": "^9.5"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,14 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="vendor/autoload.php" colors="true">
-    <testsuites>
-        <testsuite name="All tests">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="All tests">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/SlimSession/Helper.php
+++ b/src/SlimSession/Helper.php
@@ -17,7 +17,7 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      * Get a session variable.
      *
      * @param string $key
-     * @param mixed $default
+     * @param mixed  $default
      *
      * @return mixed
      */
@@ -30,7 +30,7 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      * Set a session variable.
      *
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      *
      * @return $this
      */
@@ -45,7 +45,7 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      * Merge values recursively.
      *
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      *
      * @return $this
      */
@@ -151,7 +151,7 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      * Magic method for set.
      *
      * @param string $key
-     * @param mixed $value
+     * @param mixed  $value
      */
     public function __set($key, $value): void
     {

--- a/src/SlimSession/Helper.php
+++ b/src/SlimSession/Helper.php
@@ -17,11 +17,11 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      * Get a session variable.
      *
      * @param string $key
-     * @param mixed  $default
+     * @param mixed $default
      *
      * @return mixed
      */
-    public function get($key, $default = null)
+    public function get($key, $default = null): mixed
     {
         return $this->exists($key) ? $_SESSION[$key] : $default;
     }
@@ -30,11 +30,11 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      * Set a session variable.
      *
      * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return $this
      */
-    public function set($key, $value)
+    public function set($key, $value): self
     {
         $_SESSION[$key] = $value;
 
@@ -45,11 +45,11 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      * Merge values recursively.
      *
      * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return $this
      */
-    public function merge($key, $value)
+    public function merge($key, $value): self
     {
         if (is_array($value) && is_array($old = $this->get($key))) {
             $value = array_merge_recursive($old, $value);
@@ -65,7 +65,7 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return $this
      */
-    public function delete($key)
+    public function delete($key): self
     {
         if ($this->exists($key)) {
             unset($_SESSION[$key]);
@@ -79,7 +79,7 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return $this
      */
-    public function clear()
+    public function clear(): self
     {
         $_SESSION = [];
 
@@ -93,7 +93,7 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return bool
      */
-    public function exists($key)
+    public function exists($key): bool
     {
         return array_key_exists($key, $_SESSION);
     }
@@ -105,7 +105,7 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return string
      */
-    public static function id($new = false)
+    public static function id($new = false): string
     {
         if ($new && session_id()) {
             session_regenerate_id(true);
@@ -142,7 +142,7 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return mixed
      */
-    public function __get($key)
+    public function __get($key): mixed
     {
         return $this->get($key);
     }
@@ -151,9 +151,9 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      * Magic method for set.
      *
      * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
      */
-    public function __set($key, $value)
+    public function __set($key, $value): void
     {
         $this->set($key, $value);
     }
@@ -175,7 +175,7 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return bool
      */
-    public function __isset($key)
+    public function __isset($key): bool
     {
         return $this->exists($key);
     }
@@ -185,7 +185,7 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($_SESSION);
     }
@@ -195,7 +195,7 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return \Traversable
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new \ArrayIterator($_SESSION);
     }
@@ -207,7 +207,7 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return boolean
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->exists($offset);
     }
@@ -219,7 +219,7 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @return mixed
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->get($offset);
     }
@@ -230,7 +230,7 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      * @param mixed $offset
      * @param mixed $value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->set($offset, $value);
     }
@@ -240,7 +240,7 @@ class Helper implements \ArrayAccess, \Countable, \IteratorAggregate
      *
      * @param mixed $offset
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         $this->delete($offset);
     }

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -7,7 +7,7 @@ session_start();
 
 class HelperTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         $_SESSION = [];
     }


### PR DESCRIPTION
Hi.

I am using the slim-session. thank you!

Now, I want to use this with php8.1.

But, The slim-session get some deprecated errors in PHP 8.1 env.

```
# vendor/bin/phpunit
PHPUnit 9.5.10 by Sebastian Bergmann and contributors.

.
Deprecated: Return type of SlimSession\Helper::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /src/src/SlimSession/Helper.php on line 210

...
```

I have two choice.

- use `#[ReturnTypeWillChange]` to all warned methods.
- add return type to methods to all warned methods. (but drop PHP7 support)

I tried the add return type way. and seems work fine.

![image](https://user-images.githubusercontent.com/870716/144622770-96c8bb3d-542e-477c-b5ec-76640af4b701.png)


This pull request is a report and a just sample code. (I thought, other choice is the right way for a library.)
You are welcome to reject this pull request.

thanks.

