### PR TITLE
Added flexibility in session creation

### DIFF
--- a/src/Slim/Middleware/Session.php
+++ b/src/Slim/Middleware/Session.php
@@ -80,7 +80,7 @@ class Session
     ): Response {
 
         if ($this->settings['autostart']) {
-        $this->startSession();
+            $this->startSession();
         }
 
         return $handler->handle($request);
@@ -89,8 +89,12 @@ class Session
     /**
      * Start session
      */
-    public function startSession()
+    public function startSession($sessionId=null)
     {
+        if ($sessionId) {
+            session_id($sessionId);
+        }
+
         if (session_status() !== PHP_SESSION_NONE) {
             return;
         }

--- a/src/Slim/Middleware/Session.php
+++ b/src/Slim/Middleware/Session.php
@@ -133,4 +133,9 @@ class Session
             }
         }
     }
+
+    public function getSetting($settingKey)
+    {
+        return $this->settings[$settingKey] ?? null;
+    }
 }

--- a/src/Slim/Middleware/Session.php
+++ b/src/Slim/Middleware/Session.php
@@ -48,6 +48,7 @@ class Session
             'autorefresh' => false,
             'handler' => null,
             'ini_settings' => [],
+            'autostart' => true
         ];
         $settings = array_merge($defaults, $settings);
 
@@ -77,7 +78,10 @@ class Session
         Request $request,
         RequestHandler $handler
     ): Response {
+
+        if ($this->settings['autostart']) {
         $this->startSession();
+        }
 
         return $handler->handle($request);
     }
@@ -85,7 +89,7 @@ class Session
     /**
      * Start session
      */
-    protected function startSession()
+    public function startSession()
     {
         if (session_status() !== PHP_SESSION_NONE) {
             return;


### PR DESCRIPTION
- Can now decide if the session should automatically start or not by using a setting passed into the constructor for Session.
- Can use getSetting function to obtain the value of a given setting
- Can pass your own sessionid into startSession so that it will use the existing one instead of creating a new one