### PR TITLE
Added php session flexibility

### DIFF
--- a/src/Slim/Middleware/Session.php
+++ b/src/Slim/Middleware/Session.php
@@ -80,7 +80,7 @@ class Session
     ): Response {
 
         if ($this->settings['autostart']) {
-        $this->startSession();
+            $this->startSession();
         }
 
         return $handler->handle($request);
@@ -89,8 +89,12 @@ class Session
     /**
      * Start session
      */
-    public function startSession()
+    public function startSession($sessionId=null)
     {
+        if ($sessionId) {
+            session_id($sessionId);
+        }
+
         if (session_status() !== PHP_SESSION_NONE) {
             return;
         }

--- a/src/Slim/Middleware/Session.php
+++ b/src/Slim/Middleware/Session.php
@@ -133,4 +133,9 @@ class Session
             }
         }
     }
+
+    public function getSetting($settingKey)
+    {
+        return $this->settings[$settingKey] ?? null;
+    }
 }

--- a/src/Slim/Middleware/Session.php
+++ b/src/Slim/Middleware/Session.php
@@ -48,6 +48,7 @@ class Session
             'autorefresh' => false,
             'handler' => null,
             'ini_settings' => [],
+            'autostart' => true
         ];
         $settings = array_merge($defaults, $settings);
 
@@ -77,7 +78,10 @@ class Session
         Request $request,
         RequestHandler $handler
     ): Response {
+
+        if ($this->settings['autostart']) {
         $this->startSession();
+        }
 
         return $handler->handle($request);
     }
@@ -85,7 +89,7 @@ class Session
     /**
      * Start session
      */
-    protected function startSession()
+    public function startSession()
     {
         if (session_status() !== PHP_SESSION_NONE) {
             return;


### PR DESCRIPTION
These changes allow you to call startSession with your own custom $id

In some circumstances you may want to specify the $id which would normally be used within session_id(), currently a session identifier value can only be obtained using session_start() which restricts it to the cookie value, or a GET / POST request parameter. If you, for instance, wanted to use a session identifier value that came from an HTTP header, or some other location.

sessionStart() takes an optional $id parameter, and if that is passed in you would call session_id($id) before starting the session so that the correct session will be picked up by the session handler.

You can configure the autostart setting to false to prevent the __invoke method from starting a new session.

the getSetting function is public so that you can access settings (such as the name parameter) in your middleware or routes.